### PR TITLE
add ember-cli-babel 8 to version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
          - node-babel-6
          - ember-2.0-babel-7
          - ember-babel-7
+         - ember-babel-8
 
     steps:
     - uses: actions/checkout@v1

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -51,7 +51,17 @@ module.exports = function() {
             'testem': '~2.0.0'
           }
         }
-      }
+      },
+      {
+        name: 'ember-babel-8',
+        npm: {
+          devDependencies: {
+            'ember-cli-babel': '^8.0.0',
+            'ember-data': '~3.7.0',
+            'testem': '~2.0.0'
+          }
+        }
+      },      
     ]
   };
 };

--- a/index.js
+++ b/index.js
@@ -52,7 +52,8 @@ module.exports = {
     const emberBabelChecker = this.parentChecker.for('ember-cli-babel', 'npm');
 
     this._usingBabel6 = emberBabelChecker.satisfies('^6.0.0-beta.1');
-    this._usingBabel7 = emberBabelChecker.satisfies('^7.0.0-beta.1');
+    // ember-cli-babel 7 and 8 both use babel 7
+    this._usingBabel7 = emberBabelChecker.satisfies('^7.0.0-beta.1') || emberBabelChecker.satisfies('^8.0.0');
 
     if (!this._usingBabel6 && !this._usingBabel7) {
       host.project.ui.writeWarnLine(


### PR DESCRIPTION
```
WARNING: ember-compatibility-helpers: You are using an unsupported ember-cli-babel version, compatibility helper tranforms will not be included automatically
WARNING: ember-cli-typescript requires ember-cli-babel ^7.7.3, but you have version 8.0.0 installed; your TypeScript files may not be transpiled correctly.
WARNING: ember-compatibility-helpers: You are using an unsupported ember-cli-babel version, compatibility helper tranforms will not be included automatically
WARNING: ember-compatibility-helpers: You are using an unsupported ember-cli-babel version, compatibility helper tranforms will not be included automatically
WARNING: ember-compatibility-helpers: You are using an unsupported ember-cli-babel version, compatibility helper tranforms will not be included automatically
WARNING: ember-cli-typescript requires ember-cli-babel ^7.7.3, but you have version 8.0.0 installed; your TypeScript files may not be transpiled correctly.
WARNING: ember-compatibility-helpers: You are using an unsupported ember-cli-babel version, compatibility helper tranforms will not be included automatically
WARNING: ember-compatibility-helpers: You are using an unsupported ember-cli-babel version, compatibility helper tranforms will not be included automatically
WARNING: ember-cli-typescript requires ember-cli-babel ^7.1.0, but you have version 8.0.0 installed; your TypeScript files may not be transpiled correctly.
```