### PR TITLE
drop node < 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
     - name: install dependencies
       run: yarn install
     - name: lint:js
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows]
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v1
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
     - name: install dependencies
       run: yarn install --ignore-lockfile
     - name: ember test


### PR DESCRIPTION
latest release tooling doesn't support node < 14.

This library is on its way out, so we don't _really_ need to formally drop support, it's just we don't really have a way to differentiate between development node, and consuming node in ci right now.